### PR TITLE
Update license line in Python files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-# Ultralytics 🚀 - AGPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics Template 🚀, AGPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics Template library.

--- a/template/__init__.py
+++ b/template/__init__.py
@@ -1,3 +1,3 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
 
 __version__ = "0.0.0"

--- a/template/module1.py
+++ b/template/module1.py
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
 
 
 def add_numbers(a, b):

--- a/tests/test_module1.py
+++ b/tests/test_module1.py
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
 
 from module1 import add_numbers
 


### PR DESCRIPTION
This pull request updates or adds the license line to the beginning of each Python file.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated license wording in multiple project files to include a direct link to the Ultralytics license page.

### 📊 Key Changes
- Added reference link to Ultralytics license in `.github/workflows/format.yml`.
- Modified `pyproject.toml` to include the license link.
- Updated license details in `__init__.py` and `module1.py`.
- Revised licensing information in test files.

### 🎯 Purpose & Impact
- **Enhanced Clarity**: Including a direct link to the license document ensures that users can easily access and understand the licensing terms.
- **Consistency**: All project files now uniformly reference the official Ultralytics license page.
- **User Convenience**: Reducing confusion and improving the ease of finding legal terms benefits both new and existing users.