### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/template/__init__.py
+++ b/template/__init__.py
@@ -1,3 +1,3 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 __version__ = "0.0.0"

--- a/template/module1.py
+++ b/template/module1.py
@@ -1,5 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
-
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 def add_numbers(a, b):
     """

--- a/tests/test_module1.py
+++ b/tests/test_module1.py
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from template.module1 import add_numbers
 


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚