### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-# Ultralytics Template 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests
 
 name: Template CI

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics Template library.


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved license formatting and consistency in project files 🎉  

### 📊 Key Changes  
- Updated license text in CI workflow files and project configuration (`pyproject.toml`) to include a consistent format and URL link to the license.  

### 🎯 Purpose & Impact  
- 🧹 **Consistency:** Ensures all files in the repository use a uniform license format, making it more professional and clear.  
- 🔗 **Clarity:** Adds a clickable link to the license for quick user access, fostering transparency and trust.  
- 📦 **No Functional Changes:** This PR is a cosmetic/documentation update, so there’s no direct impact on the code or user-facing features.