### PR TITLE
Add CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@
 # Continuous Integration (CI) GitHub Actions tests
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@
 # Continuous Integration (CI) GitHub Actions tests
 
 name: CI
+
 permissions:
-  contents: read
+  contents: read # Read code in PRs
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/template/security/code-scanning/2](https://github.com/ultralytics/template/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's actions, the minimal required permission is `contents: read`, as the workflow primarily installs dependencies, runs tests, and uploads coverage reports. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub Actions workflow security for the project’s continuous integration process. 🔒🚀

### 📊 Key Changes
- Added explicit permissions for GitHub Actions, allowing only read access to repository contents during CI runs.

### 🎯 Purpose & Impact
- Enhances security by limiting what the CI workflow can access.
- Reduces the risk of unauthorized changes or data exposure during automated tests.
- Provides safer and more robust automation for all contributors and users.