### PR TITLE
Remove legacy docformatter references

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI
-          python: true # Format Python with Ruff and docformatter
+          python: true # Format Python with Ruff
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: false # Format Swift (requires macos-latest)
           spelling: true # Check spelling with codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,13 +106,6 @@ docstring-code-format = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.docformatter]
-wrap-summaries = 120
-wrap-descriptions = 120
-pre-summary-newline = true
-close-quotes-on-newline = true
-in-place = true
-
 [tool.codespell]
 ignore-words-list = "crate,nd,strack,dota,ane,segway,fo,gool,winn,commend"
 skip = '*.csv,*venv*,docs/??/,docs/mkdocs_??.yml'


### PR DESCRIPTION
Based on https://github.com/ultralytics/handbook/pull/205#issuecomment-3536904391

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Remove legacy `docformatter` references from formatting workflow comments and project configuration to align with the current Ruff-only formatting setup.

### 📊 Key Changes
- Updated `.github/workflows/format.yml` comment to state Python is formatted with Ruff (removing `docformatter` mention).
- Removed obsolete `[tool.docformatter]` configuration block from `pyproject.toml`.

### 🎯 Purpose & Impact
- Prevents confusion by reflecting the actual toolchain (Ruff only) used for Python formatting.
- Simplifies project configuration by dropping unused `docformatter` settings.
- Reduces maintenance overhead and potential mismatch between tooling and configuration for contributors.
