### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.9", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [# Optional, for a list of valid classifiers, see https://pypi.org
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## Summary
- advertise Python 3.14 support in package classifiers
- include Python 3.14 in the CI test matrix

## Tests
- python -c "import tomllib; tomllib.load(open("pyproject.toml", "rb"))"
- actionlint .github/workflows/*.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR adds early Python 3.14 support to the `ultralytics/template` project by updating CI testing and package metadata.

### 📊 Key Changes
- ✅ Added Python `3.14` to the GitHub Actions CI test matrix in `.github/workflows/ci.yml`
- 🏷️ Added the Python `3.14` classifier to `pyproject.toml`
- 🌍 Keeps existing multi-platform testing coverage across Ubuntu, macOS, and Windows

### 🎯 Purpose & Impact
- 🔮 Prepares the template for upcoming Python releases, helping projects stay current
- 🧪 Ensures automated testing can catch Python 3.14 compatibility issues early
- 📦 Signals to users and package indexes that the project is intended to support Python 3.14
- 👩‍💻 Makes the template more future-ready for developers starting new projects from `ultralytics/template`