### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           example-cli-command
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./pytest-coverage.xml,./unittest-coverage.xml # optional (default = coverage.xml)


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `codecov/codecov-action@v7` instead of `@v6` for uploading test coverage reports.

### 📊 Key Changes
- ⬆️ Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml` from `codecov/codecov-action@v6` to `codecov/codecov-action@v7`
- 🧪 Kept the existing coverage upload configuration unchanged, including the `CODECOV_TOKEN` secret and coverage report file paths
- ⚙️ No application code, tests, or user-facing features were changed

### 🎯 Purpose & Impact
- 🔐 Helps keep CI dependencies current, which can improve security and maintainability
- 🚀 Ensures compatibility with the latest Codecov action updates and fixes
- 👩‍💻 Low-risk infrastructure change with little to no impact on end users, but beneficial for repository maintenance and CI reliability