### PR TITLE
Fix Codecov badge and OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 
 permissions:
   contents: read # Read code in PRs
+  id-token: write # Required for Codecov OIDC authentication
 
 on:
   push:
@@ -62,6 +63,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./pytest-coverage.xml,./unittest-coverage.xml # optional (default = coverage.xml)
           flags: template_coverage # optional
+          use_oidc: true
+          fail_ci_if_error: true
+          disable_search: true
+          plugins: noop

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to the Ultralytics Python Project Template! This repository provides a s
 
 [![Template CI](https://github.com/ultralytics/template/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/template/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/template/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/template/actions/workflows/format.yml)
-[![codecov](https://codecov.io/gh/ultralytics/template/graph/badge.svg?token=K9IunpFzjS)](https://codecov.io/gh/ultralytics/template)
+[![codecov](https://codecov.io/github/ultralytics/template/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/template)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- replace the tokenized Codecov README badge with the public main-branch badge
- switch the Codecov upload step to GitHub OIDC auth and fail loudly
- keep the existing coverage files and flag while disabling extra report search/plugins

## Validation
- ruby YAML parse for .github/workflows/*.yml
- actionlint .github/workflows/ci.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR modernizes Codecov integration in the Ultralytics template by switching CI coverage uploads to OIDC authentication and updating the README coverage badge links.

### 📊 Key Changes
- Added `id-token: write` permission in the GitHub Actions CI workflow to support Codecov OIDC authentication.
- Updated the Codecov upload step to:
  - remove the `CODECOV_TOKEN` secret requirement
  - enable `use_oidc: true`
  - set `fail_ci_if_error: true`
  - set `disable_search: true`
  - use `plugins: noop`
- Kept explicit coverage file uploads for `pytest` and `unittest` reports.
- Updated the README Codecov badge:
  - changed the badge URL to the newer branch-specific Codecov format
  - changed the link target to the current Codecov app URL

### 🎯 Purpose & Impact
- 🚀 Simplifies CI setup by removing dependency on a stored Codecov token secret.
- 🔒 Improves security by using GitHub’s OIDC-based authentication instead of secret-based authentication.
- ✅ Makes coverage reporting more reliable by failing CI if Codecov upload errors occur.
- 🧹 Reduces ambiguity in uploads by disabling automatic file search and relying on explicitly provided coverage files.
- 📈 Keeps repository badges and links up to date, so users see accurate coverage status in the README.