### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.9", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v6` to `actions/checkout@v7`.

### 📊 Key Changes
- Upgraded the CI workflow in `.github/workflows/ci.yml`
- Replaced `actions/checkout@v6` with `actions/checkout@v7`
- No application code or model behavior was changed; this is a workflow maintenance update 🛠️

### 🎯 Purpose & Impact
- Improves CI workflow maintenance by keeping GitHub Actions dependencies up to date ✅
- Helps ensure better compatibility with the latest GitHub Actions ecosystem
- May provide security, reliability, or performance improvements from the newer action version 🔒
- Has little to no direct impact on end users, but can make automated testing and development workflows more stable for contributors 🚀