### PR TITLE
Prefer uv pip install in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ After opening a PR:
 ## Commands
 
 ```bash
-pip install -e ".[dev]" # install for development
+uv pip install -e ".[dev]" # install for development
 
 pytest tests -v                                               # run tests (pytest)
 pytest tests/test_with_pytest.py::test_add_numbers -v         # run one test
@@ -41,7 +41,7 @@ python -m unittest discover tests -v                          # run tests (unitt
 pytest tests -v --cov=./ --cov-report=xml:pytest-coverage.xml # coverage (CI command)
 example-cli-command                                           # run the example CLI entry point
 
-ruff format . && ruff check --fix . # format/lint (pip install ruff; config in pyproject.toml)
+ruff format . && ruff check --fix . # format/lint (uv pip install ruff; config in pyproject.toml)
 ```
 
 CI matrix: Python 3.9/3.13/3.14 × ubuntu/macos/windows. CI runs the tests four ways — pytest and unittest, each with and without coverage — plus the CLI entry point, so tests must pass under both runners.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome to the Ultralytics Python Project Template! This repository provides a s
 
 This template is meticulously organized for intuitive navigation and a clear understanding of project components. Familiarize yourself with the [Python project structure best practices](https://realpython.com/python-application-layouts/) to make the most of this layout.
 
-- `src/` or `your_package_name/`: Contains the core source code of your Python package, organized into modules. Using a `src` layout is a common practice detailed in [Python packaging guides](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata).
+- `your_package_name/` (here `template/`) or `src/`: Contains the core source code of your Python package, organized into modules. The alternative `src` layout is detailed in [Python packaging guides](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata).
 - `tests/`: Dedicated directory for unit tests and integration tests, crucial for implementing [continuous testing](https://docs.ultralytics.com/help/CI) practices. Consider using frameworks like [pytest](https://docs.pytest.org/en/stable/) for writing tests.
 - `docs/`: (Optional) Houses project documentation. Tools like [MkDocs](https://www.mkdocs.org/) can be used to generate comprehensive documentation from this directory.
 - `pyproject.toml`: The standard configuration file for Python projects, detailing dependencies, build system requirements, formatting rules, and packaging information as specified by [PEP 518](https://peps.python.org/pep-0518/) and subsequent PEPs.
@@ -33,13 +33,11 @@ your-project/
 ├── your_package_name/          # Or src/ for src-layout
 │   ├── __init__.py
 │   ├── module1.py
-│   ├── module2.py
 │   └── ...
 │
-├── tests/                      # Test suite
-│   ├── __init__.py
-│   ├── test_module1.py
-│   └── ...
+├── tests/                      # Test suite (pytest + unittest examples)
+│   ├── test_with_pytest.py
+│   └── test_with_unittest.py
 │
 ├── docs/                       # Documentation files (optional)
 │   └── ...
@@ -58,9 +56,9 @@ your-project/
 └── README.md                   # This file
 ```
 
-### 📦 Source Code Directory (`src/` or `your_package_name/`)
+### 📦 Source Code Directory (`your_package_name/` or `src/`)
 
-The `src/` or `your_package_name/` directory is the heart of your project, containing the Python code that constitutes your package. Adopting a structured layout promotes clean imports and simplifies testing and packaging.
+The `your_package_name/` or `src/` directory is the heart of your project, containing the Python code that constitutes your package. Adopting a structured layout promotes clean imports and simplifies testing and packaging.
 
 ### 🧪 Testing Directory (`tests/`)
 


### PR DESCRIPTION
Use `uv pip install` instead of bare `pip install` in AGENTS.md commands for speed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the project template docs to promote `uv` for development installs and clarify the recommended package/test directory layout 📚✨

### 📊 Key Changes
- Replaced `pip install -e ".[dev]"` with `uv pip install -e ".[dev]"` in `AGENTS.md` ⚡
- Updated the Ruff install hint to use `uv pip install ruff` 🛠️
- Clarified that the package directory can be `your_package_name/` such as `template/`, or alternatively `src/` 📦
- Simplified the example project tree by removing extra placeholder files and aligning test examples with actual pytest/unittest files 🧪
- Refined wording around source code layout to make the template easier to understand for new projects 📝

### 🎯 Purpose & Impact
- Encourages faster, more consistent dependency installation with `uv` 🚀
- Makes setup instructions more aligned with modern Python development workflows 🐍
- Reduces confusion for users starting from the template by showing clearer, more realistic folder examples ✅
- Helps both new and experienced developers understand how to organize code and tests in projects based on `ultralytics/template` 🤝