### PR TITLE
Add publish.yml release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/template' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
+    if: github.repository == 'ultralytics/template' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/template' && github.ref == 'refs/heads/main'
+    if: github.repository == 'ultralytics/template' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,8 @@ jobs:
             git config --global user.email "web@ultralytics.com"
             git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
             git push origin "$CURRENT_TAG"
+          fi
+          if ! gh release view "$CURRENT_TAG" >/dev/null 2>&1; then
             ultralytics-actions-summarize-release
           fi
           uv cache prune --ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/template'
+    if: github.repository == 'ultralytics/template' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -57,7 +57,7 @@ jobs:
           fi
           OLD_VERSION=$(git show "$BASE:template/__init__.py" | sed -n 's/^__version__ = "\(.*\)"$/\1/p')
           NEW_VERSION=$(python -c 'import template; print(template.__version__)')
-          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ] && [ -z "$(git tag -l "v$NEW_VERSION")" ]; then
             INCREMENT=True
             echo "Version changed $OLD_VERSION → $NEW_VERSION, ready to tag and release ✅."
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,183 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Tag, release, and (optionally) publish pip package to PyPI on version increment
+
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pypi:
+        type: boolean
+        description: Publish to PyPI
+
+jobs:
+  check:
+    if: github.repository == 'ultralytics/template' && github.actor == 'glenn-jocher'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      increment: ${{ steps.check_version.outputs.increment }}
+      current_tag: ${{ steps.check_version.outputs.current_tag }}
+      previous_tag: ${{ steps.check_version.outputs.previous_tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - uses: astral-sh/setup-uv@v7
+      - run: uv pip install --system --no-cache ultralytics-actions
+      # This template gates on __version__ changing in the pushed diff since the 'template' name on
+      # PyPI belongs to an unrelated package. When publishing your own package, replace this step
+      # with the PyPI version check used in
+      # https://github.com/ultralytics/mkdocs/blob/main/.github/workflows/publish.yml:
+      #
+      # - id: check_pypi
+      #   shell: python
+      #   run: |
+      #     import os
+      #     from actions.utils import check_pypi_version
+      #     local_version, online_version, publish = check_pypi_version()
+      #     os.system(f'echo "increment={publish}" >> $GITHUB_OUTPUT')
+      #     os.system(f'echo "current_tag=v{local_version}" >> $GITHUB_OUTPUT')
+      #     os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
+      #     if publish:
+      #         print('Ready to publish new version to PyPI ✅.')
+      - id: check_version
+        env:
+          BASE: ${{ github.event.before }}
+        run: |
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE=$(git rev-parse HEAD~1)
+          fi
+          OLD_VERSION=$(git show "$BASE:template/__init__.py" | sed -n 's/^__version__ = "\(.*\)"$/\1/p')
+          NEW_VERSION=$(python -c 'import template; print(template.__version__)')
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            INCREMENT=True
+            echo "Version changed $OLD_VERSION → $NEW_VERSION, ready to tag and release ✅."
+          else
+            INCREMENT=False
+          fi
+          {
+            echo "increment=$INCREMENT"
+            echo "current_tag=v$NEW_VERSION"
+            echo "previous_tag=v$OLD_VERSION"
+          } >> "$GITHUB_OUTPUT"
+      - name: Tag and Release
+        if: steps.check_version.outputs.increment == 'True'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ steps.check_version.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ steps.check_version.outputs.previous_tag }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          git config --global user.name "UltralyticsAssistant"
+          git config --global user.email "web@ultralytics.com"
+          git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
+          git push origin "$CURRENT_TAG"
+          ultralytics-actions-summarize-release
+          uv cache prune --ci
+
+  build:
+    needs: check
+    if: needs.check.outputs.increment == 'True'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - uses: astral-sh/setup-uv@v7
+      - run: uv pip install --system --no-cache build
+      - run: python -m build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+      - run: uv cache prune --ci
+
+  publish:
+    needs: [check, build]
+    if: needs.check.outputs.increment == 'True'
+    runs-on: ubuntu-latest
+    # To publish to PyPI: rename the package in pyproject.toml, set up PyPI trusted publishing
+    # (https://docs.pypi.org/trusted-publishers/), then uncomment the lines below.
+    #
+    # environment: # for GitHub Deployments tab
+    #   name: Release - PyPI
+    #   url: https://pypi.org/p/template
+    # permissions:
+    #   id-token: write # for PyPI trusted publishing
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      # - uses: pypa/gh-action-pypi-publish@release/v1
+
+  sbom:
+    needs: [check, build, publish]
+    if: needs.check.outputs.increment == 'True'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - uses: astral-sh/setup-uv@v7
+      - run: |
+          uv venv sbom-env
+          uv pip install -e .
+        env:
+          VIRTUAL_ENV: sbom-env
+      - uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+          path: sbom-env
+      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    needs: [check, publish]
+    if: always() && needs.check.outputs.increment == 'True'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Get release title
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
+        run: |
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+      - name: Notify Success
+        if: needs.publish.result == 'success' && github.event_name == 'push'
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
+          payload: |
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
+      - name: Notify Failure
+        if: needs.publish.result != 'success'
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
+          payload: |
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   check:
+    # Templates omit the github.actor maintainer gate that product repos keep for security; forks add their own.
     if: github.repository == 'ultralytics/template' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -51,6 +52,7 @@ jobs:
       - id: check_version
         env:
           BASE: ${{ github.event.before }}
+          PYPI_DISPATCH: ${{ github.event.inputs.pypi }}
         run: |
           if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
             BASE=$(git rev-parse HEAD~1)
@@ -60,7 +62,7 @@ jobs:
           if [ "$NEW_VERSION" != "$OLD_VERSION" ] && [ -z "$(git tag -l "v$NEW_VERSION")" ]; then
             INCREMENT=True
             echo "Version changed $OLD_VERSION → $NEW_VERSION, ready to tag and release ✅."
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          elif [ "$PYPI_DISPATCH" = "true" ]; then
             INCREMENT=True # manual recovery re-run for v$NEW_VERSION after a partial failure
           else
             INCREMENT=False

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/template' && github.actor == 'glenn-jocher'
+    if: github.repository == 'ultralytics/template'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -107,14 +107,15 @@ jobs:
     needs: [check, build]
     if: needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # To publish to PyPI: rename the package in pyproject.toml, set up PyPI trusted publishing
-    # (https://docs.pypi.org/trusted-publishers/), then uncomment the lines below.
+    # (https://docs.pypi.org/trusted-publishers/), then uncomment the lines below and add
+    # 'id-token: write' to the permissions above.
     #
     # environment: # for GitHub Deployments tab
     #   name: Release - PyPI
     #   url: https://pypi.org/p/template
-    # permissions:
-    #   id-token: write # for PyPI trusted publishing
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -149,7 +150,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
-    needs: [check, publish]
+    needs: [check, publish, sbom]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
     permissions:
@@ -166,7 +167,7 @@ jobs:
           TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
-        if: needs.publish.result == 'success' && github.event_name == 'push'
+        if: needs.publish.result == 'success' && needs.sbom.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
@@ -174,7 +175,7 @@ jobs:
           payload: |
             text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
-        if: needs.publish.result != 'success'
+        if: needs.publish.result != 'success' || needs.sbom.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,8 @@ jobs:
           if [ "$NEW_VERSION" != "$OLD_VERSION" ] && [ -z "$(git tag -l "v$NEW_VERSION")" ]; then
             INCREMENT=True
             echo "Version changed $OLD_VERSION → $NEW_VERSION, ready to tag and release ✅."
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            INCREMENT=True # manual recovery re-run for v$NEW_VERSION after a partial failure
           else
             INCREMENT=False
           fi
@@ -76,11 +78,13 @@ jobs:
           PREVIOUS_TAG: ${{ steps.check_version.outputs.previous_tag }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          git config --global user.name "UltralyticsAssistant"
-          git config --global user.email "web@ultralytics.com"
-          git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
-          git push origin "$CURRENT_TAG"
-          ultralytics-actions-summarize-release
+          if [ -z "$(git tag -l "$CURRENT_TAG")" ]; then
+            git config --global user.name "UltralyticsAssistant"
+            git config --global user.email "web@ultralytics.com"
+            git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
+            git push origin "$CURRENT_TAG"
+            ultralytics-actions-summarize-release
+          fi
           uv cache prune --ci
 
   build:
@@ -145,7 +149,7 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           path: sbom-env
-      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json
+      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ CI matrix: Python 3.9/3.13/3.14 × ubuntu/macos/windows. CI runs the tests four 
 
 ## Architecture
 
-This is the Ultralytics template for new Python packages — a minimal, fully wired example meant to be copied and adapted. `template/` is the package: `__init__.py` holds `__version__` (read by setuptools dynamic versioning in `pyproject.toml`), and `module1.py` holds the example `add_numbers()`/`main()` backing the `example-cli-command` entry point in `[project.scripts]`. `tests/` demonstrates the same tests in both pytest style (`test_with_pytest.py`) and unittest style (`test_with_unittest.py`). `format.yml` runs Ultralytics Actions on PRs (Ruff, Prettier, codespell, link checks, AI labels/summaries) and commits fixes back to the PR branch.
+This is the Ultralytics template for new Python packages — a minimal, fully wired example meant to be copied and adapted. `template/` is the package: `__init__.py` holds `__version__` (read by setuptools dynamic versioning in `pyproject.toml`), and `module1.py` holds the example `add_numbers()`/`main()` backing the `example-cli-command` entry point in `[project.scripts]`. `tests/` demonstrates the same tests in both pytest style (`test_with_pytest.py`) and unittest style (`test_with_unittest.py`). `format.yml` runs Ultralytics Actions on PRs (Ruff, Prettier, codespell, link checks, AI labels/summaries) and commits fixes back to the PR branch. `publish.yml` tags, releases, and (optionally) publishes to PyPI when `__version__` is bumped on `main`; its `check` job intentionally omits the `github.actor` maintainer gate that product repos keep for security, because a fork supplies its own.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ your-project/
 ├── .github/                    # GitHub Actions workflows
 │   └── workflows/
 │       ├── ci.yml
-│       └── format.yml
+│       ├── format.yml
+│       └── publish.yml
 │
 ├── .gitignore                  # Git ignore rules
 ├── .pre-commit-config.yaml     # Pre-commit hook config (optional)


### PR DESCRIPTION
## 🛠️ Summary

Adds a `publish.yml` workflow mirroring the release pipeline used in [ultralytics/mkdocs](https://github.com/ultralytics/mkdocs/blob/main/.github/workflows/publish.yml) and [ultralytics/ultralytics](https://github.com/ultralytics/ultralytics/blob/main/.github/workflows/publish.yml), adapted for this template:

- **Version gate**: fires when `__version__` in `template/__init__.py` changes in the pushed diff (compares `github.event.before` → `HEAD`, falling back to `HEAD~1`). The sibling repos gate on `check_pypi_version()`, but the `template` name on PyPI belongs to an unrelated package at 0.7.6, so that check would never fire here; the original step is left commented for forks to restore.
- **Tag + Release**: tags `v{version}`, pushes the tag, and generates an AI release summary via `ultralytics-actions-summarize-release`.
- **Build**: builds sdist/wheel and uploads the `dist/` artifact.
- **PyPI publish**: intentionally commented out (environment, `id-token` permission, and `pypa/gh-action-pypi-publish` step) with notes on enabling trusted publishing when forking this template into a real package.
- **SBOM**: SPDX SBOM generated and attached to the GitHub release.
- **Notify**: Slack success/failure notifications.

## 🧪 Testing

- YAML validated with `yaml.safe_load`.
- `check_version` gate logic dry-run locally under bash: no version change → `increment=False`, simulated bump → `increment=True`; bump-then-revert within one push correctly yields no release.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a complete GitHub Actions release workflow for the Ultralytics Python package template, enabling automated tagging, release creation, builds, SBOM generation, and optional PyPI publishing 🚀

### 📊 Key Changes
- Added a new `.github/workflows/publish.yml` workflow for release automation 📦
- Detects version bumps in `template/__init__.py` on `main` and creates a matching Git tag and GitHub Release 🏷️
- Builds Python distribution artifacts using `python -m build` and uploads them as workflow artifacts 🛠️
- Includes a placeholder PyPI publishing step with guidance for enabling trusted publishing 🔐
- Generates and uploads an SPDX JSON SBOM to the GitHub Release for supply-chain transparency 📄
- Adds Slack notifications for release success or failure 🔔
- Updates `AGENTS.md` to document the new publishing workflow and its security assumptions
- Updates `README.md` project tree to include `publish.yml`

### 🎯 Purpose & Impact
- Streamlines package release management for projects created from this template ⚡
- Reduces manual work by automating tags, releases, builds, and release notes generation 🤖
- Improves security and compliance with SBOM generation and PyPI trusted publishing guidance 🛡️
- Makes the template more production-ready while keeping PyPI publishing disabled by default for safe customization ✅
- Helps maintainers quickly adapt the workflow for their own forked or renamed packages 🧩