### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,12 @@ jobs:
           example-cli-command
 
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           files: ./pytest-coverage.xml,./unittest-coverage.xml # optional (default = coverage.xml)
           flags: template_coverage # optional
           use_oidc: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           disable_search: true
           plugins: noop


### PR DESCRIPTION
## Summary\n- make the Codecov upload step non-blocking\n- keep existing coverage files, OIDC, flags, and plugins settings\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CI reliability by making Codecov coverage uploads non-blocking ✅

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step in GitHub Actions.
- Changed Codecov setting `fail_ci_if_error` from `true` to `false`.
- Keeps coverage reporting enabled while preventing external upload issues from failing the entire CI pipeline.

### 🎯 Purpose & Impact
- Reduces false CI failures caused by temporary Codecov outages, network issues, or upload errors 🚀
- Helps developers focus on actual test and code failures instead of third-party service problems.
- Maintains visibility into test coverage without making it a required gate for PR success 📈