### PR TITLE
Bump slackapi/slack-github-action from v3.0.3 to v3.0.5 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && needs.sbom.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -184,7 +184,7 @@ jobs:
             text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success' || needs.sbom.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.3 to v3.0.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Slack GitHub Action used for release notifications from `v3.0.3` to `v3.0.5`. 📣

### 📊 Key Changes

- Updated the `slackapi/slack-github-action` dependency in `.github/workflows/publish.yml`.
- Applied the update to both:
  - ✅ Release success notifications
  - ❌ Release failure notifications

### 🎯 Purpose & Impact

- Keeps Slack notifications aligned with the latest action release. 🔄
- May provide bug fixes, security improvements, and better compatibility with GitHub Actions.
- Does not change release logic or notification content; it only updates the action version.