### PR TITLE
Queue publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Publish to PyPI
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     # Templates omit the github.actor maintainer gate that product repos keep for security; forks add their own.


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`.
- Preserve up to 100 pending release runs instead of replacing older pending releases.
- Align release robustness with [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) without changing the repository-specific publisher.

Deleted: nothing — GitHub owns workflow scheduling, so preserving pending release runs requires workflow-level concurrency configuration.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds concurrency control to the publishing workflow to manage simultaneous release runs more reliably. ⚙️

### 📊 Key Changes

- Added a workflow-level concurrency group based on the GitHub Actions workflow name.
- Configured queued execution with `queue: max`, allowing all triggered publish runs to wait their turn.
- Applied the change to `.github/workflows/publish.yml`.

### 🎯 Purpose & Impact

- Prevents multiple publish workflows from running concurrently and potentially interfering with one another. 🔒
- Ensures publish requests are processed sequentially rather than canceled or executed in parallel.
- Improves reliability for repeated or closely timed PyPI publishing operations. 📦