### PR TITLE
Trim copy-pasted pyproject config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ dev = [
 [project.urls]  # Optional
 "Homepage" = "https://ultralytics.com"
 "Source" = "https://github.com/ultralytics/template"
-"Documentation" = "https://docs.ultralytics.com"
 "Bug Reports" = "https://github.com/ultralytics/template/issues"
 "Changelog" = "https://github.com/ultralytics/template/releases"
 
@@ -104,7 +103,3 @@ docstring-code-format = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-[tool.codespell]
-ignore-words-list = "crate,nd,strack,dota,ane,segway,fo,gool,winn,commend"
-skip = '*.csv,*venv*,docs/??/,docs/mkdocs_??.yml'


### PR DESCRIPTION
Two leftovers copied from `ultralytics/ultralytics` that do not apply here. Since new Ultralytics Python projects are copied from this repo, both propagate.

- Removed the `[tool.codespell]` table. Every word in `ignore-words-list` (`strack`, `dota`, `segway`, `crate`, …) is a YOLO-specific term, and the only place any of them appears in this repo is that line itself; the `skip` globs point at `*.csv`, `docs/??/` and `docs/mkdocs_??.yml`, none of which exist here. Ultralytics Actions already passes its own comprehensive `--ignore-words-list` on the command line, and I verified codespell still reports clean on this repo with the table gone.
- Dropped the `Documentation` project URL. docs.ultralytics.com hosts the YOLO documentation, not docs for this package, so the link sends users somewhere unrelated. The remaining Homepage/Source/Bug Reports/Changelog URLs are correct.

Verified locally: TOML parses, `pip install -e ".[dev]"`, `pytest` (7 passed) and `example-cli-command` all fine.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Simplifies the project configuration by removing outdated documentation and codespell settings. 🧹

### 📊 Key Changes

- Removed the `"Documentation"` URL from `pyproject.toml`.
- Deleted the `[tool.codespell]` configuration, including custom ignored words and skipped file patterns.

### 🎯 Purpose & Impact

- Keeps the template’s package metadata more focused and up to date. ✨
- Removes repository-specific spelling exceptions and exclusions that may no longer be needed.
- Could allow codespell to check a broader set of files and flag previously ignored terms, depending on the active tooling configuration. 🔍